### PR TITLE
Filter (non-)instantiatable classes

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,6 +8,8 @@ return (function (): Config
     $paths = [
         __DIR__ . DIRECTORY_SEPARATOR . 'src',
         __DIR__ . DIRECTORY_SEPARATOR . 'tests',
+        __DIR__ . DIRECTORY_SEPARATOR . 'test-app',
+        __DIR__ . DIRECTORY_SEPARATOR . 'test-classes',
     ];
 
     return PhpCsFixerConfig::create()

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ composer require wyrihaximus/list-classes-in-directory
 #### get a list of classes from multiple directories.
 ```php
 use function WyriHaximus\listClassesInDirectories;
+use function WyriHaximus\listInstantiatableClassesInDirectories;
+use function WyriHaximus\listNonInstantiatableClassesInDirectories;
 
 // $classes now contains a list of full qualified class names from 'src/' and 'tests/'
 $classes = listClassesInDirectories(
@@ -28,12 +30,23 @@ $classes = listClassesInDirectories(
 );
 ```
 
+// use listInstantiatableClassesInDirectories() or listNonInstantiatableClassesInDirectories() to only consider classes that can actually be instantiated, or not.
+$instantiatableClasses = listInstantiatableClassesInDirectory(__DIR__ . '/src', __DIR__ . '/tests');
+$nonInstantiatableClasses = listNonInstantiatableClassesInDirectory(____DIR__ . '/src', __DIR__ . '/tests'__);
+
 #### get a list of classes from one directory.
 ```php
 use function WyriHaximus\listClassesInDirectory;
+use function WyriHaximus\listInstantiatableClassesInDirectory;
+use function WyriHaximus\listNonInstantiatableClassesInDirectory;
 
 // $classes now contains a list of full qualified class names from __DIR__
 $classes = listClassesInDirectory(__DIR__);
+
+// use listInstantiatableClassesInDirectory() or listNonInstantiatableClassesInDirectory() to only consider classes that can actually be instantiated, or not.
+$instantiatableClasses = listInstantiatableClassesInDirectory(__DIR__);
+$nonInstantiatableClasses = listNonInstantiatableClassesInDirectory(__DIR__);
+
 ```
 #### get a list of classes from multiple files.
 ```php

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
   "autoload-dev": {
     "psr-4": {
       "WyriHaximus\\Tests\\": "tests/",
-      "Test\\App\\": "test-app/"
+      "Test\\App\\": "test-app/",
+      "Test\\Classes\\": "test-classes/"
     }
   },
   "config": {

--- a/test-app/Commands/AwesomesauceCommand.php
+++ b/test-app/Commands/AwesomesauceCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Test\App\Commands;
 

--- a/test-app/Foo/Bar/BarAndFoo.php
+++ b/test-app/Foo/Bar/BarAndFoo.php
@@ -1,12 +1,11 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Test\App\Foo\Bar;
 
-class Bar {
-
+class Bar
+{
 }
 
 class Foo extends Bar
 {
-    
 }

--- a/test-app/Handlers/AwesomesauceHandler.php
+++ b/test-app/Handlers/AwesomesauceHandler.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Test\App\Handlers;
 
@@ -7,7 +7,7 @@ use Test\App\Commands\AwesomesauceCommand;
 class AwesomesauceHandler
 {
     /**
-     * @param AwesomesauceCommand $command
+     * @param  AwesomesauceCommand $command
      * @return string
      */
     public function handler(AwesomesauceCommand $command)

--- a/test-classes/InstantiatableClass.php
+++ b/test-classes/InstantiatableClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Test\Classes;
+
+class InstantiatableClass {
+
+}

--- a/test-classes/InstantiatableClass.php
+++ b/test-classes/InstantiatableClass.php
@@ -1,7 +1,7 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Test\Classes;
 
-class InstantiatableClass {
-
+class InstantiatableClass
+{
 }

--- a/test-classes/NonInstantiatableClass.php
+++ b/test-classes/NonInstantiatableClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Test\Classes;
+
+abstract class NonInstantiatableClass {
+
+}

--- a/test-classes/NonInstantiatableClass.php
+++ b/test-classes/NonInstantiatableClass.php
@@ -1,7 +1,7 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Test\Classes;
 
-abstract class NonInstantiatableClass {
-
+abstract class NonInstantiatableClass
+{
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -7,6 +7,8 @@ use Test\App\Commands\AwesomesauceCommand;
 use Test\App\Foo\Bar\Bar;
 use Test\App\Foo\Bar\Foo;
 use Test\App\Handlers\AwesomesauceHandler;
+use Test\Classes\InstantiatableClass;
+use Test\Classes\NonInstantiatableClass;
 use const DIRECTORY_SEPARATOR;
 use const SORT_NATURAL;
 use function dirname;
@@ -15,6 +17,8 @@ use function WyriHaximus\listClassesInDirectories;
 use function WyriHaximus\listClassesInDirectory;
 use function WyriHaximus\listClassesInFile;
 use function WyriHaximus\listClassesInFiles;
+use function WyriHaximus\listInstantiatableClassesInDirectory;
+use function WyriHaximus\listNonInstantiatableClassesInDirectory;
 
 final class FunctionalTest extends TestCase
 {
@@ -70,6 +74,28 @@ final class FunctionalTest extends TestCase
             Bar::class,
             Foo::class,
             AwesomesauceHandler::class,
+        ], $classes);
+    }
+
+    public function testListInstantiatableClassesInDirectory(): void
+    {
+        $directory = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'test-classes' . DIRECTORY_SEPARATOR ;
+        $classes = iterator_to_array(listInstantiatableClassesInDirectory($directory));
+        sort($classes, SORT_NATURAL);
+
+        self::assertSame([
+            InstantiatableClass::class,
+        ], $classes);
+    }
+
+    public function testListNonInstantiatableClassesInDirectory(): void
+    {
+        $directory = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'test-classes' . DIRECTORY_SEPARATOR ;
+        $classes = iterator_to_array(listNonInstantiatableClassesInDirectory($directory));
+        sort($classes, SORT_NATURAL);
+
+        self::assertSame([
+            NonInstantiatableClass::class,
         ], $classes);
     }
 }


### PR DESCRIPTION
As suggested in https://github.com/WyriHaximus/php-list-classes-in-directory/issues/8

Note I tried to use the classes in `test-app`, but they seem to not follow the PSR4 standard (each class should have its own file), so when using them to set up a ReflectionClass, it always failed with a "class not found" exception: 

```
Roave\BetterReflection\Reflector\Exception\IdentifierNotFound: Roave\BetterReflection\Reflection\ReflectionClass "Test\App\Foo\Bar\Bar" could not be found in the located source
```

So I decided to use separate classes for testing this "feature" 🤓 